### PR TITLE
hotfix: 빠른 변경 사항을 위한 PR

### DIFF
--- a/WhatIsKickboard/Data/Mock/Kickboard+Mock.swift
+++ b/WhatIsKickboard/Data/Mock/Kickboard+Mock.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-@testable import WhatIsKickboard
 
 // MARK: - Kickboard Mock
 extension Kickboard {

--- a/WhatIsKickboard/Data/Mock/KickboardRide+Mock.swift
+++ b/WhatIsKickboard/Data/Mock/KickboardRide+Mock.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-@testable import WhatIsKickboard
 
 // MARK: - KickboardRide Mock
 extension KickboardRide {

--- a/WhatIsKickboard/Data/Mock/User+Mock.swift
+++ b/WhatIsKickboard/Data/Mock/User+Mock.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-@testable import WhatIsKickboard
 
 // MARK: - User Mock
 extension User {

--- a/WhatIsKickboard/Presentation/Shared/Extension/Extension+UIFont.swift
+++ b/WhatIsKickboard/Presentation/Shared/Extension/Extension+UIFont.swift
@@ -1,0 +1,20 @@
+//
+//  Extension+UIFont.swift
+//  WhatIsKickboard
+//
+//  Created by 유영웅 on 4/29/25.
+//
+
+import UIKit
+
+// MARK: 커스텀 폰트 적용
+extension UIFont {
+    
+    static func jalnan2(_ size: CGFloat) -> Self {
+        return UIFont(name: "Jalnan2", size: size) as! Self
+    }
+    
+    static func jalnan2TTF(_ size: CGFloat) -> Self {
+        return UIFont(name: "Jalnan2TTF", size: size) as! Self
+    }
+}


### PR DESCRIPTION
- 범용적으로 사용하기 위해 UIFont Extension으로 추가
- Mock 데이터 Data Layer로 이동

```swift
extension UIFont {
    
    static func jalnan2(_ size: CGFloat) -> Self {
        return UIFont(name: "Jalnan2", size: size) as! Self
    }
    
    static func jalnan2TTF(_ size: CGFloat) -> Self {
        return UIFont(name: "Jalnan2TTF", size: size) as! Self
    }
}

```