### PR TITLE
feat: #27 - 마이페이지 화면 (이름, 비밀번호 수정 및 회원탈퇴) 기능 구현

### DIFF
--- a/WhatIsKickboard.xcodeproj/project.pbxproj
+++ b/WhatIsKickboard.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N676ZFA7W8;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WhatIsKickboard/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -354,7 +354,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N676ZFA7W8;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WhatIsKickboard/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/WhatIsKickboard/App/SceneDelegate.swift
+++ b/WhatIsKickboard/App/SceneDelegate.swift
@@ -52,7 +52,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
+    
+    static func switchToSplash() {
+        guard let window = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first?.windows
+                .first else { return }
 
-
+        window.rootViewController = UINavigationController(rootViewController: SplashViewController())
+        window.makeKeyAndVisible()
+    }
 }
 

--- a/WhatIsKickboard/App/SceneDelegate.swift
+++ b/WhatIsKickboard/App/SceneDelegate.swift
@@ -59,7 +59,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 .first?.windows
                 .first else { return }
 
-        window.rootViewController = UINavigationController(rootViewController: SplashViewController())
+        window.rootViewController = SplashViewController()
         window.makeKeyAndVisible()
     }
 }

--- a/WhatIsKickboard/Presentation/Main/MyPage/ModifyType.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/ModifyType.swift
@@ -10,6 +10,7 @@ import Foundation
 enum ModifyType: String {
     case name
     case password
+    case withdrawal
     
     var navigationTitle: String {
         switch self {
@@ -17,6 +18,8 @@ enum ModifyType: String {
             return "이름 수정"
         case .password:
             return "비밀번호 수정"
+        case .withdrawal:
+            return "회원 탈퇴"
         }
     }
     
@@ -26,6 +29,17 @@ enum ModifyType: String {
             return "이름 수정"
         case .password:
             return "비밀번호"
+        case .withdrawal:
+            return "비밀번호"
+        }
+    }
+    
+    var rightBarButtonTitle: String {
+        switch self {
+        case .name, .password:
+            return "수정"
+        case .withdrawal:
+            return "탈퇴"
         }
     }
 }

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/Components/PobyGreetingView.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/Components/PobyGreetingView.swift
@@ -31,13 +31,6 @@ final class PobyGreetingView: BaseView {
         }
         
         userNameGreetingLabel.do {
-            let text = "회원님, 안녕하세요!"
-            let attributedString = NSMutableAttributedString(string: text)
-            attributedString.addAttribute(.foregroundColor, value: UIColor(hex: "#69C6D3"), range: (text as NSString).range(of: "회원"))
-            attributedString.addAttribute(.foregroundColor, value: UIColor.black, range: (text as NSString).range(of: "님, 안녕하세요!"))
-
-            $0.attributedText = attributedString
-            $0.font = UIFont(name: "Jalnan2", size: 28)
             $0.textAlignment = .center
         }
         

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyStackView.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyStackView.swift
@@ -61,10 +61,9 @@ final class ModifyStackView: UIStackView {
             modifyTextFiled.placeholder = modidyType.placeholder
             modifyCheckTextFiled.isHidden = true
         } else {
-            modifyTextFiled.placeholder = modidyType.placeholder + " 수정"
+            modifyTextFiled.placeholder = modidyType.placeholder + " 입력"
             modifyCheckTextFiled.placeholder = modidyType.placeholder + " 확인"
         }
-        
     }
     
     // MARK: - Layouts

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewController.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewController.swift
@@ -15,8 +15,9 @@ import Then
 // MARK: - View Life Cycle
 final class ModifyViewController: BaseViewController {
         
-    // MARK: - UI Components
+    // MARK: - Components
     private let modifyView = ModifyView()
+    private var customAlertView: CustomAlertView?
     
     // MARK: - Properties
     private var modityType: ModifyType
@@ -71,7 +72,6 @@ final class ModifyViewController: BaseViewController {
                 case .withdrawal:
                     let passwordText = owner.modifyView.modifyStackView.modifyTextFiled.text ?? ""
                     let passwordCheckText = owner.modifyView.modifyStackView.modifyCheckTextFiled.text ?? ""
-                    owner.modifyViewModel.action.onNext(.password(passwordText, passwordCheckText))
                     owner.modifyViewModel.action.onNext(.withdrawal(passwordText, passwordCheckText))
                 }
             }
@@ -79,15 +79,93 @@ final class ModifyViewController: BaseViewController {
     }
     
     override func bindViewModel() {
+        modifyViewModel.state.nameStatus
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                print("유저 이름이 정상적으로 수정되었습니다.")
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
         
+        modifyViewModel.state.passwordStatus
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                print("유저 비밀번호가 정상적으로 수정되었습니다.")
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        modifyViewModel.state.withDrawalStatus
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                print("유저 회원탈퇴가 정상적으로 수행되었습니다.")
+                SceneDelegate.switchToSplash()
+            }
+            .disposed(by: disposeBag)
+        
+        modifyViewModel.state.errorMessage
+            .bind(with: self) { owner, message in
+                owner.showModifyAlert(message)
+            }
+            .disposed(by: disposeBag)
     }
 
     override func setStyles() {
-        modifyView.navigationBarView.configure(title: modityType.navigationTitle, showsRightButton: true, rightButtonTitle: modityType.rightBarButtonTitle)
+        switch modityType {
+        case .name:
+            break
+        case .password, .withdrawal:
+            modifyView.modifyStackView.modifyTextFiled.do {
+                $0.keyboardType = .default
+                $0.isSecureTextEntry = true
+            }
+            
+            modifyView.modifyStackView.modifyCheckTextFiled.do {
+                $0.keyboardType = .default
+                $0.isSecureTextEntry = true
+            }
+        }
+        
+        modifyView.navigationBarView.configure(
+            title: modityType.navigationTitle,
+            showsRightButton: true,
+            rightButtonTitle: modityType.rightBarButtonTitle)
+        
         modifyView.modifyStackView.configure(modityType)
     }
     
     override func setLayout() {
 
+    }
+    
+    private func showModifyAlert(_ message: String) {
+        let alert = CustomAlertView(frame: .zero, alertType: .failureUserModify)
+        view.addSubview(alert)
+        
+        alert.configure(name: message)
+        
+        alert.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        alert.getSubmitButton().rx.tap
+            .bind(with: self) { owner, _ in
+                owner.dismissAlertView(alert)
+            }
+            .disposed(by: disposeBag)
+        
+        alert.getCancelButton().rx.tap
+            .bind(with: self) { owner, _ in
+                owner.dismissAlertView(alert)
+            }
+            .disposed(by: disposeBag)
+
+        self.customAlertView = alert
+    }
+    
+    private func dismissAlertView(_ alert: CustomAlertView) {
+        alert.removeFromSuperview()
+        self.customAlertView = nil
+        self.tabBarController?.tabBar.isHidden = true
     }
 }

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewController.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewController.swift
@@ -20,6 +20,7 @@ final class ModifyViewController: BaseViewController {
     
     // MARK: - Properties
     private var modityType: ModifyType
+    private let modifyViewModel = ModifyViewModel()
     
     init(modityType: ModifyType) {
         self.modityType = modityType
@@ -35,6 +36,12 @@ final class ModifyViewController: BaseViewController {
         view = modifyView
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        bindUIEvents()
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -42,7 +49,7 @@ final class ModifyViewController: BaseViewController {
         self.tabBarController?.tabBar.isHidden = true
     }
     
-    override func bindViewModel() {
+    private func bindUIEvents() {
         modifyView.navigationBarView.getBackButton().rx.tap
             .bind(with: self) { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
@@ -53,13 +60,30 @@ final class ModifyViewController: BaseViewController {
         modifyView.navigationBarView.getRightButton().rx.tap
             .bind(with: self) { owner, _ in
                 print("저장버튼")
+                switch owner.modityType {
+                case .name:
+                    let nameText = owner.modifyView.modifyStackView.modifyTextFiled.text ?? ""
+                    owner.modifyViewModel.action.onNext(.name(nameText))
+                case .password:
+                    let passwordText = owner.modifyView.modifyStackView.modifyTextFiled.text ?? ""
+                    let passwordCheckText = owner.modifyView.modifyStackView.modifyCheckTextFiled.text ?? ""
+                    owner.modifyViewModel.action.onNext(.password(passwordText, passwordCheckText))
+                case .withdrawal:
+                    let passwordText = owner.modifyView.modifyStackView.modifyTextFiled.text ?? ""
+                    let passwordCheckText = owner.modifyView.modifyStackView.modifyCheckTextFiled.text ?? ""
+                    owner.modifyViewModel.action.onNext(.password(passwordText, passwordCheckText))
+                    owner.modifyViewModel.action.onNext(.withdrawal(passwordText, passwordCheckText))
+                }
             }
             .disposed(by: disposeBag)
+    }
+    
+    override func bindViewModel() {
         
     }
 
     override func setStyles() {
-        modifyView.navigationBarView.configure(title: modityType.navigationTitle, showsRightButton: true, rightButtonTitle: "저장")
+        modifyView.navigationBarView.configure(title: modityType.navigationTitle, showsRightButton: true, rightButtonTitle: modityType.rightBarButtonTitle)
         modifyView.modifyStackView.configure(modityType)
     }
     
@@ -67,4 +91,3 @@ final class ModifyViewController: BaseViewController {
 
     }
 }
-

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewModel.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewModel.swift
@@ -14,6 +14,7 @@ enum ModifyError: String, Error {
     case nameEmpty = "빈 값으로는 변경할 수 없습니다."
     case passwordEmpty = "비밀번호를 입력해주세요."
     case passwordNotSame = "비밀번호를 확인해주세요."
+    case unknownError = "회원정보 수정을 실패하였습니다."
 }
 
 final class ModifyViewModel: ViewModelProtocol {
@@ -24,69 +25,110 @@ final class ModifyViewModel: ViewModelProtocol {
     }
 
     struct State {
-        let nameStatus = PublishSubject<User>()
-        let passwordStatus = PublishSubject<User>()
-        let withDrawalStatus = PublishSubject<String>()
+        let nameStatus = PublishRelay<Void>()
+        let passwordStatus = PublishRelay<Void>()
+        let withDrawalStatus = PublishRelay<Void>()
+        let errorMessage = PublishRelay<String>()
     }
 
     private let actionSubject = PublishSubject<Action>()
     
     var action: AnyObserver<Action> { actionSubject.asObserver() }
-
+    
     let state = State()
+    var user: User?
     let disposeBag = DisposeBag()
 
     init() {
         bind()
+        loadUser()
     }
     
     private func bind() {
         actionSubject
             .subscribe(with: self) { owner, action in
-                switch action {
+                switch action {                    
                 case .name(let name):
                     owner.accessNameModify(name)
                 case .password(let password, let passwordCheck):
                     owner.accessPasswordModify(password, passwordCheck)
                 case .withdrawal(let password, let passwordCheck):
-                    owner.accessWithdrawalModify(password, passwordCheck)
+                    Task {
+                        try await owner.accessWithdrawalModify(password, passwordCheck)
+                    }
                 }
             }
             .disposed(by: disposeBag)
     }
     
+    /// 유저정보 불러오기
+    func loadUser() {
+        UserPersistenceManager.getUser()
+            .subscribe(with: self, onSuccess: { owner, user in
+                owner.user = user
+            }, onFailure: { owner, error in
+                print(error.localizedDescription)
+            })
+            .disposed(by: disposeBag)
+    }
+    
     private func accessNameModify(_ name: String) {
-        if name.isEmpty {
-            state.nameStatus.onError(ModifyError.nameEmpty)
-        } else {
-            // API 호출 후 onNext 필요 (patchUser)
-//            state.nameStatus.onNext(<#T##element: User##User#>)
+        guard !name.isEmpty else {
+            state.errorMessage.accept(ModifyError.nameEmpty.rawValue)
+            return
         }
+        guard var user else { return }
+        user.name = name
+        
+        UserPersistenceManager.patchUser(user)
+            .subscribe(with: self, onSuccess: { owner, user in
+                owner.state.nameStatus.accept(())
+            }, onFailure: { owner, _ in
+                owner.state.errorMessage.accept(ModifyError.unknownError.rawValue)
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     private func accessPasswordModify(_ password: String, _ passwordCheck: String) {
-        if password.isEmpty {
-            state.passwordStatus.onError(ModifyError.passwordEmpty)
-        } else if
-            (!password.isEmpty && passwordCheck.isEmpty) ||
-            (password != passwordCheck) {
-            state.passwordStatus.onError(ModifyError.passwordNotSame)
-        } else if password == passwordCheck {
-            // API 호출 후 onNext 필요 (patchUser)
-//            state.passwordStatus.onNext(<#T##element: User##User#>)
+        switch validatePassword(password, passwordCheck) {
+        case .success:
+            guard var user else { return }
+            user.password = passwordCheck
+            
+            UserPersistenceManager.patchUser(user)
+                .subscribe(with: self, onSuccess: { owner, user in
+                    owner.state.passwordStatus.accept(())
+                }, onFailure: { owner, _ in
+                    owner.state.errorMessage.accept(ModifyError.unknownError.rawValue)
+                })
+                .disposed(by: disposeBag)
+        case .failure(let error):
+            state.errorMessage.accept(error.rawValue)
+        }
+    }
+
+    private func accessWithdrawalModify(_ password: String, _ passwordCheck: String) async throws {
+        switch validatePassword(password, passwordCheck) {
+        case .success:
+            do {
+                try await UserPersistenceManager.deleteUser(password: passwordCheck)
+                state.withDrawalStatus.accept(())
+            } catch let error as UserPersistenceError {
+                state.errorMessage.accept(error.rawValue)
+            }
+        case .failure(let error):
+            state.errorMessage.accept(error.rawValue)
         }
     }
     
-    private func accessWithdrawalModify(_ password: String, _ passwordCheck: String) {
+    private func validatePassword(_ password: String, _ passwordCheck: String) -> Result<Void, ModifyError> {
         if password.isEmpty {
-            state.passwordStatus.onError(ModifyError.passwordEmpty)
-        } else if
-            (!password.isEmpty && passwordCheck.isEmpty) ||
-            (password != passwordCheck) {
-            state.passwordStatus.onError(ModifyError.passwordNotSame)
-        } else if password == passwordCheck {
-            // API 호출 후 onNext 필요 (patchUser)
-//            state.passwordStatus.onNext(<#T##element: User##User#>)
+            return .failure(.passwordEmpty)
+        } else if passwordCheck.isEmpty || password != passwordCheck {
+            return .failure(.passwordNotSame)
+        } else {
+            return .success(())
         }
     }
 }

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewModel.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/Modify/ModifyViewModel.swift
@@ -1,0 +1,92 @@
+//
+//  ModifyViewModel.swift
+//  WhatIsKickboard
+//
+//  Created by 백래훈 on 4/30/25.
+//
+
+import Foundation
+
+import RxSwift
+import RxRelay
+
+enum ModifyError: String, Error {
+    case nameEmpty = "빈 값으로는 변경할 수 없습니다."
+    case passwordEmpty = "비밀번호를 입력해주세요."
+    case passwordNotSame = "비밀번호를 확인해주세요."
+}
+
+final class ModifyViewModel: ViewModelProtocol {
+    enum Action {
+        case name(String)
+        case password(String, String)
+        case withdrawal(String, String)
+    }
+
+    struct State {
+        let nameStatus = PublishSubject<User>()
+        let passwordStatus = PublishSubject<User>()
+        let withDrawalStatus = PublishSubject<String>()
+    }
+
+    private let actionSubject = PublishSubject<Action>()
+    
+    var action: AnyObserver<Action> { actionSubject.asObserver() }
+
+    let state = State()
+    let disposeBag = DisposeBag()
+
+    init() {
+        bind()
+    }
+    
+    private func bind() {
+        actionSubject
+            .subscribe(with: self) { owner, action in
+                switch action {
+                case .name(let name):
+                    owner.accessNameModify(name)
+                case .password(let password, let passwordCheck):
+                    owner.accessPasswordModify(password, passwordCheck)
+                case .withdrawal(let password, let passwordCheck):
+                    owner.accessWithdrawalModify(password, passwordCheck)
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func accessNameModify(_ name: String) {
+        if name.isEmpty {
+            state.nameStatus.onError(ModifyError.nameEmpty)
+        } else {
+            // API 호출 후 onNext 필요 (patchUser)
+//            state.nameStatus.onNext(<#T##element: User##User#>)
+        }
+    }
+    
+    private func accessPasswordModify(_ password: String, _ passwordCheck: String) {
+        if password.isEmpty {
+            state.passwordStatus.onError(ModifyError.passwordEmpty)
+        } else if
+            (!password.isEmpty && passwordCheck.isEmpty) ||
+            (password != passwordCheck) {
+            state.passwordStatus.onError(ModifyError.passwordNotSame)
+        } else if password == passwordCheck {
+            // API 호출 후 onNext 필요 (patchUser)
+//            state.passwordStatus.onNext(<#T##element: User##User#>)
+        }
+    }
+    
+    private func accessWithdrawalModify(_ password: String, _ passwordCheck: String) {
+        if password.isEmpty {
+            state.passwordStatus.onError(ModifyError.passwordEmpty)
+        } else if
+            (!password.isEmpty && passwordCheck.isEmpty) ||
+            (password != passwordCheck) {
+            state.passwordStatus.onError(ModifyError.passwordNotSame)
+        } else if password == passwordCheck {
+            // API 호출 후 onNext 필요 (patchUser)
+//            state.passwordStatus.onNext(<#T##element: User##User#>)
+        }
+    }
+}

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageView.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageView.swift
@@ -54,6 +54,8 @@ final class MyPageView: BaseView {
             $0.configuration = config
             $0.contentHorizontalAlignment = .center
         }
+        
+        usingKickboardView.isHidden = true
     }
     
     // MARK: - Layouts
@@ -62,10 +64,10 @@ final class MyPageView: BaseView {
         
         self.addSubviews(pobyGreetingView, usingKickboardView, dividingLine, myPageStackView, withDrawalButton)
         
-//        pobyGreetingView.snp.makeConstraints {
-//            $0.top.equalTo(safeAreaLayoutGuide)
-//            $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
-//        }
+        pobyGreetingView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
+        }
         
         usingKickboardView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
@@ -73,7 +75,7 @@ final class MyPageView: BaseView {
         }
         
         dividingLine.snp.makeConstraints {
-            $0.top.equalTo(usingKickboardView.snp.bottom).offset(16)
+            $0.top.equalTo(pobyGreetingView.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
             $0.height.equalTo(1)
         }

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageViewController.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageViewController.swift
@@ -19,6 +19,9 @@ final class MyPageViewController: BaseViewController {
     private let myPageView = MyPageView()
     private var customAlertView: CustomAlertView?
     
+    // MARK: - Properties
+    private var user: User?
+    
     let myPageViewModel = MyPageViewModel()
     
     // MARK: - View Life Cycle
@@ -30,7 +33,7 @@ final class MyPageViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        myPageViewModel.action.onNext(.viewDidLoad)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -42,6 +45,25 @@ final class MyPageViewController: BaseViewController {
     // MARK: - bindViewModel
     override func bindViewModel() {
         super.bindViewModel()
+        
+        /// 회원정보 보여주기
+        myPageViewModel.state.user
+            .subscribe(with: self, onNext: { owner, user in
+                owner.user = user
+                guard let user = owner.user, let name = user.name else { return }
+                
+                let attributedText = NSMutableAttributedString.makeAttributedString(
+                    text: "\(name)님, 안녕하세요!",
+                    highlightedParts: [
+                        (name, .core, UIFont.jalnan2(28)),
+                        ("님, 안녕하세요!", .black, UIFont.jalnan2(28))
+                    ]
+                )
+                owner.myPageView.pobyGreetingView.userNameGreetingLabel.attributedText = attributedText
+            }, onError: { owner, error in
+                print("\(owner.className) 유저 정보를 찾을 수 없습니다!")
+            })
+            .disposed(by: disposeBag)
         
         /// 이름 수정 (modifyNameButton)
         myPageView.myPageStackView.modifyNameButton.rx.tap
@@ -109,7 +131,9 @@ final class MyPageViewController: BaseViewController {
         let alert = CustomAlertView(frame: .zero, alertType: .logout)
         view.addSubview(alert)
         
-        alert.configure(name: "회원님", minutes: nil, count: nil, price: nil)
+        guard let user, let name = user.name else { return }
+        
+        alert.configure(name: name)
         
         alert.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -134,7 +158,9 @@ final class MyPageViewController: BaseViewController {
         let alert = CustomAlertView(frame: .zero, alertType: .deleteID)
         view.addSubview(alert)
         
-        alert.configure(name: "회원님", minutes: nil, count: nil, price: nil)
+        guard let user, let name = user.name else { return }
+        
+        alert.configure(name: name)
         
         alert.snp.makeConstraints {
             $0.edges.equalToSuperview()

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageViewController.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageViewController.swift
@@ -94,6 +94,7 @@ final class MyPageViewController: BaseViewController {
                 owner.tabBarController?.tabBar.isHidden = true
             }
             .disposed(by: disposeBag)
+        
     }
     
     // MARK: - bindViewModel
@@ -120,6 +121,14 @@ final class MyPageViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         /// 최종적으로 AlertView에서 로그아웃 버튼이 눌린 경우
+        myPageViewModel.state.accessLogout
+            .bind(with: self) { owner, _ in
+                UserPersistenceManager.logout()
+                SceneDelegate.switchToSplash()
+            }
+            .disposed(by: disposeBag)
+        
+        /// 최종적으로 AlertView에서  버튼이 눌린 경우
         myPageViewModel.state.accessLogout
             .bind(with: self) { owner, _ in
                 UserPersistenceManager.logout()
@@ -160,7 +169,7 @@ final class MyPageViewController: BaseViewController {
         alert.getSubmitButton().rx.tap
             .bind(with: self) { owner, _ in
                 owner.dismissAlertView(alert)
-                owner.myPageViewModel.action.onNext(.logoutAction)
+                 owner.myPageViewModel.action.onNext(.logoutAction)
             }
             .disposed(by: disposeBag)
         
@@ -188,6 +197,7 @@ final class MyPageViewController: BaseViewController {
         alert.getSubmitButton().rx.tap
             .bind(with: self) { owner, _ in
                 owner.dismissAlertView(alert)
+                owner.pushNavigationController(ModifyViewController(modityType: .withdrawal))
             }
             .disposed(by: disposeBag)
         

--- a/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageViewController.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/View/MyPageViewController.swift
@@ -34,7 +34,6 @@ final class MyPageViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        bindAction()
         bindUIEvents()
     }
     
@@ -42,11 +41,13 @@ final class MyPageViewController: BaseViewController {
         super.viewWillAppear(animated)
         self.navigationController?.navigationBar.isHidden = true
         self.tabBarController?.tabBar.isHidden = false
+        
+        bindAction()
     }
     
     // MARK: - bindAction
     private func bindAction() {
-        myPageViewModel.action.onNext(.viewDidLoad)
+        myPageViewModel.action.onNext(.viewWillAppear)
     }
     
     // MARK: - bindUIEvents
@@ -106,7 +107,6 @@ final class MyPageViewController: BaseViewController {
             .subscribe(with: self, onNext: { owner, user in
                 owner.user = user
                 guard let user = owner.user, let name = user.name else { return }
-                
                 let attributedText = NSMutableAttributedString.makeAttributedString(
                     text: "\(name)님, 안녕하세요!",
                     highlightedParts: [

--- a/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
@@ -65,12 +65,13 @@ private extension MyPageViewModel {
             .disposed(by: disposeBag)
     }
     
+    /// 로그아웃 처리하기
     func logoutProgress() {
         state.accessLogout.accept(())
     }
     
+    /// 회원탈퇴 처리하기
     func withDrawalProgress() {
-        // 회원탈퇴 비즈니스 로직 처리 필요
         state.accessWithDrawal.accept(())
     }
 }

--- a/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
@@ -66,7 +66,6 @@ private extension MyPageViewModel {
     }
     
     func logoutProgress() {
-        // 로그아웃 비즈니스 로직 처리 필요
         state.accessLogout.accept(())
     }
     

--- a/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
@@ -13,11 +13,13 @@ import RxRelay
 final class MyPageViewModel: ViewModelProtocol {
 
     enum Action {
+        case viewDidLoad
         case logoutAction
         case withDrawalAction
     }
 
     struct State {
+        let user = PublishSubject<User>()
         let accessLogout = PublishRelay<Void>()
         let accessWithDrawal = PublishRelay<Void>()
     }
@@ -37,6 +39,8 @@ final class MyPageViewModel: ViewModelProtocol {
         actionSubject
             .subscribe(with: self) { owner, action in
                 switch action {
+                case .viewDidLoad:
+                    owner.loadUser()
                 case .logoutAction:
                     owner.logoutProgress()
                 case .withDrawalAction:
@@ -45,13 +49,28 @@ final class MyPageViewModel: ViewModelProtocol {
             }
             .disposed(by: disposeBag)
     }
+}
+
+//MARK: - Extension Private Methods
+private extension MyPageViewModel {
     
-    private func logoutProgress() {
+    /// 유저정보 불러오기
+    func loadUser() {
+        UserPersistenceManager.getUser()
+            .subscribe(with: self, onSuccess: { owner, user in
+                owner.state.user.onNext(user)
+            }, onFailure: { owner, error in
+                owner.state.user.onError(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func logoutProgress() {
         // 로그아웃 비즈니스 로직 처리 필요
         state.accessLogout.accept(())
     }
     
-    private func withDrawalProgress() {
+    func withDrawalProgress() {
         // 회원탈퇴 비즈니스 로직 처리 필요
         state.accessWithDrawal.accept(())
     }

--- a/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
+++ b/WhatIsKickboard/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
@@ -13,7 +13,7 @@ import RxRelay
 final class MyPageViewModel: ViewModelProtocol {
 
     enum Action {
-        case viewDidLoad
+        case viewWillAppear
         case logoutAction
         case withDrawalAction
     }
@@ -39,7 +39,7 @@ final class MyPageViewModel: ViewModelProtocol {
         actionSubject
             .subscribe(with: self) { owner, action in
                 switch action {
-                case .viewDidLoad:
+                case .viewWillAppear:
                     owner.loadUser()
                 case .logoutAction:
                     owner.logoutProgress()

--- a/WhatIsKickboard/Presentation/Main/Return/View/CustomAlertView.swift
+++ b/WhatIsKickboard/Presentation/Main/Return/View/CustomAlertView.swift
@@ -46,7 +46,7 @@ final class CustomAlertView: BaseView {
         }
         
         switch alertType {
-        case .returnRequest, .logout, .deleteID, .emailFailed, .signIntFailed:
+        case .returnRequest, .logout, .deleteID, .emailFailed, .signIntFailed, .failureUserModify:
             imageView.do {
                 $0.image = UIImage(named: "PobyHi")
             }
@@ -109,7 +109,7 @@ final class CustomAlertView: BaseView {
     override func setLayout() {
         
         switch alertType {
-        case .returnRequest, .logout, .deleteID:
+        case .returnRequest, .logout, .deleteID, .failureUserModify:
             addSubviews(containerView)
             containerView.addSubviews(imageView, titleLabel, subtitleLabel, buttonStackView, verticalSeparator, horizontalSeparator)
             buttonStackView.addArrangedSubviews(submitButton, cancelButton)

--- a/WhatIsKickboard/Presentation/Main/Return/View/CustomAlertViewType.swift
+++ b/WhatIsKickboard/Presentation/Main/Return/View/CustomAlertViewType.swift
@@ -14,6 +14,7 @@ enum CustomAlertViewType {
     case deleteID
     case emailFailed
     case signIntFailed
+    case failureUserModify
     
     func makeTitle(name: String, minutes: Int? = nil, count: Int? = nil) -> NSAttributedString {
         let fullText: String
@@ -33,7 +34,7 @@ enum CustomAlertViewType {
             } else {
                 fullText = "\(name)님은 아직 포비와 달린적이 없어요"
             }
-        case .emailFailed, .signIntFailed:
+        case .emailFailed, .signIntFailed, .failureUserModify:
             fullText = name
         }
         
@@ -77,13 +78,15 @@ enum CustomAlertViewType {
             return "어디가~? 킥보드 말고 뭐 타려고~?"
         case .emailFailed, .signIntFailed:
             return ""
+        case .failureUserModify:
+            return "다시 시도해줄래~?"
         }
     }
     
     var submitTitle: String {
         switch self {
         case .returnRequest: return "포비와 그만 놀기"
-        case .confirmReturn, .emailFailed, .signIntFailed: return "확인"
+        case .confirmReturn, .emailFailed, .signIntFailed, .failureUserModify: return "확인"
         case .logout: return "로그아웃"
         case .deleteID: return "포비에게 도망가기"
         }
@@ -91,7 +94,7 @@ enum CustomAlertViewType {
     
     var submitTitleColor: UIColor {
         switch self {
-        case .returnRequest, .confirmReturn, .deleteID, .emailFailed, .signIntFailed: return UIColor(hex: "#6B6E82")
+        case .returnRequest, .confirmReturn, .deleteID, .emailFailed, .signIntFailed, .failureUserModify: return UIColor(hex: "#6B6E82")
         case .logout: return UIColor(hex: "#FF4F17")
         }
     }
@@ -100,7 +103,7 @@ enum CustomAlertViewType {
         switch self {
         case .returnRequest: return "더 달리기"
         case .confirmReturn, .emailFailed, .signIntFailed: return ""
-        case .logout: return "취소"
+        case .logout, .failureUserModify: return "취소"
         case .deleteID: return "포비와 더 달리기"
         }
     }

--- a/WhatIsKickboard/Presentation/Shared/Extension/Extension+NSMutableAttributedString.swift
+++ b/WhatIsKickboard/Presentation/Shared/Extension/Extension+NSMutableAttributedString.swift
@@ -64,3 +64,5 @@ extension NSMutableAttributedString {
         return attributedString
     }
 }
+
+    


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #27

</br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 이름 수정 시 마이페이지 화면에서 변경된 이름 확인
- 비밀번호 수정 시 변경된 값으로 로그인 필요
- 회원탈퇴 시 스플래쉬 뷰 화면으로 root 뷰 변경 후 앱 재시작

</br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->

| 구현 내용 | 스크린샷 | GIF |
| :-------------: | :----------: | :----------: |
| **이름 수정 전** | <img src = "https://github.com/user-attachments/assets/afe5fad6-0aa1-4701-a2ad-3b77c0bc79bf" width ="250"> | - |
| **이름 수정 화면</br>(빈 값의 상태로 수정 버튼 클릭 시)** | <img src = "https://github.com/user-attachments/assets/1fe9e275-b117-4acd-8819-d93f3dff83e2" width ="250"> | - |
| **이름 수정 화면</br>(수정할 이름 값 입력)** | <img src = "https://github.com/user-attachments/assets/95b92619-ba31-42c5-bbb0-4745272be2c0" width ="250"> | - |
| **이름 수정 후 마이페이지 화면** | <img src = "https://github.com/user-attachments/assets/094424ab-004a-4ae5-b734-1cce100cc938" width ="250"> | - |
| **비밀번호 수정 화면** | <img src = "https://github.com/user-attachments/assets/5b0f00f9-c105-43fc-a8ac-63c3b6b2ee6a" width ="250"> | - |
| **비밀번호 수정 화면</br>(비밀번호 확인이 빈 값의 상태로 수정 버튼 클릭 시)** | <img src = "https://github.com/user-attachments/assets/961619d8-39f8-4871-97b3-c0718f9752a2" width ="250"> | - |
| **비밀번호 수정 화면</br>(비밀번호와 비밀번호 확인 값이 일치하지 않을 시)** | <img src = "https://github.com/user-attachments/assets/7613c845-d7a2-4659-acea-40a9c435d079" width ="250"> | - |
| **회원탈퇴 화면** | <img src = "https://github.com/user-attachments/assets/b5bf0b59-ebeb-4077-a25c-fcd3b131033d" width ="250"> | <img src = "https://github.com/user-attachments/assets/f1629eb6-dc42-49b9-9486-f195c72ba3e1" width ="250"> |
</br>